### PR TITLE
Add cancel button to translation widget overlay

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -128,6 +128,15 @@ export default function Index() {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const handleCancel = () => {
+    setIsWidgetVisible(false);
+    // Reset widget state
+    setSourceText("");
+    setTranslatedText("");
+    setIsMinimized(false);
+    setIsExpanded(true);
+  };
+
   const handleHeaderMouseDown = (e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
     if (widgetRef.current) {

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -197,6 +197,50 @@ export default function Index() {
   const charCount = sourceText.length;
   const isOverLimit = charCount > 280;
 
+  if (!isWidgetVisible) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-gray-900 flex flex-col justify-start items-end pl-4 pr-0 py-4">
+        {/* Demo Twitter-like Background */}
+        <div className="max-w-2xl mx-auto bg-slate-800/80 backdrop-blur-sm border border-slate-700/50 rounded-2xl shadow-xl p-6 mb-4">
+          <div className="flex items-center space-x-3 mb-4">
+            <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-cyan-400 rounded-full ring-2 ring-blue-400/20"></div>
+            <div>
+              <div className="font-semibold text-white">Twitter User</div>
+              <div className="text-slate-400 text-sm">@twitteruser</div>
+            </div>
+          </div>
+          <p className="text-slate-200 mb-4 leading-relaxed">
+            This is a sample tweet that you might want to translate. The
+            translation widget floats on top and can be moved around the screen.
+          </p>
+          <div className="flex space-x-6 text-slate-400 text-sm">
+            <span className="hover:text-slate-300 cursor-pointer transition-colors">
+              Reply
+            </span>
+            <span className="hover:text-slate-300 cursor-pointer transition-colors">
+              Retweet
+            </span>
+            <span className="hover:text-slate-300 cursor-pointer transition-colors">
+              Like
+            </span>
+          </div>
+        </div>
+
+        {/* Show button to restore widget */}
+        <div className="max-w-2xl mx-auto bg-gradient-to-br from-violet-500/10 to-indigo-500/10 backdrop-blur-sm border border-violet-400/20 rounded-2xl p-6 mt-4">
+          <div className="flex items-center justify-center">
+            <Button
+              onClick={() => setIsWidgetVisible(true)}
+              className="bg-gradient-to-r from-violet-600 via-purple-600 to-indigo-600 hover:from-violet-700 hover:via-purple-700 hover:to-indigo-700 text-white font-medium shadow-lg shadow-violet-500/25 transition-all duration-200 border-0"
+            >
+              Show LiveTranslate Widget
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (isMinimized) {
     return (
       <div

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -369,6 +369,14 @@ export default function Index() {
                 >
                   <Minimize2 className="w-4 h-4" />
                 </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-8 h-8 p-0 text-slate-400 hover:text-red-400 hover:bg-red-900/20 rounded-lg transition-all"
+                  onClick={handleCancel}
+                >
+                  <X className="w-4 h-4" />
+                </Button>
               </div>
             </div>
           </CardHeader>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -33,7 +33,7 @@ const languages = [
   { code: "ko", name: "Korean", flag: "🇰🇷" },
   { code: "zh", name: "Chinese (Simplified)", flag: "🇨🇳" },
   { code: "ar", name: "Arabic", flag: "🇸🇦" },
-  { code: "hi", name: "Hindi", flag: "🇮��" },
+  { code: "hi", name: "Hindi", flag: "🇮🇳" },
   { code: "nl", name: "Dutch", flag: "🇳🇱" },
   { code: "tr", name: "Turkish", flag: "🇹🇷" },
   { code: "pl", name: "Polish", flag: "🇵🇱" },
@@ -52,6 +52,7 @@ export default function Index() {
   const [position, setPosition] = useState({ x: 20, y: 20 });
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [isWidgetVisible, setIsWidgetVisible] = useState(true);
   const widgetRef = useRef<HTMLDivElement>(null);
 
   // Check if mobile

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -314,7 +314,7 @@ export default function Index() {
         }}
       >
         <Card
-          className={`${isMobile ? "w-full" : "w-85"} bg-slate-900/95 backdrop-blur-xl border border-slate-700/50 shadow-2xl shadow-black/25 transition-all duration-300 relative group`}
+          className={`${isMobile ? "w-full" : "w-85"} bg-slate-900/95 backdrop-blur-xl border border-slate-700/50 shadow-2xl shadow-black/25 transition-all duration-300`}
         >
           {/* Header */}
           <CardHeader

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -18,6 +18,7 @@ import {
   ArrowRightLeft,
   ChevronDown,
   ChevronUp,
+  X,
 } from "lucide-react";
 
 const languages = [
@@ -32,7 +33,7 @@ const languages = [
   { code: "ko", name: "Korean", flag: "🇰🇷" },
   { code: "zh", name: "Chinese (Simplified)", flag: "🇨🇳" },
   { code: "ar", name: "Arabic", flag: "🇸🇦" },
-  { code: "hi", name: "Hindi", flag: "🇮🇳" },
+  { code: "hi", name: "Hindi", flag: "🇮��" },
   { code: "nl", name: "Dutch", flag: "🇳🇱" },
   { code: "tr", name: "Turkish", flag: "🇹🇷" },
   { code: "pl", name: "Polish", flag: "🇵🇱" },

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -381,6 +381,18 @@ export default function Index() {
             </div>
           </CardHeader>
 
+          {/* Overlay Cancel Button */}
+          <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10">
+            <Button
+              variant="destructive"
+              size="sm"
+              className="w-8 h-8 p-0 bg-red-600/90 hover:bg-red-700 text-white rounded-full shadow-lg"
+              onClick={handleCancel}
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+
           {isExpanded && (
             <CardContent className="pt-4 space-y-4">
               {/* Language Selection */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -314,7 +314,7 @@ export default function Index() {
         }}
       >
         <Card
-          className={`${isMobile ? "w-full" : "w-85"} bg-slate-900/95 backdrop-blur-xl border border-slate-700/50 shadow-2xl shadow-black/25 transition-all duration-300`}
+          className={`${isMobile ? "w-full" : "w-85"} bg-slate-900/95 backdrop-blur-xl border border-slate-700/50 shadow-2xl shadow-black/25 transition-all duration-300 relative group`}
         >
           {/* Header */}
           <CardHeader

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -381,18 +381,6 @@ export default function Index() {
             </div>
           </CardHeader>
 
-          {/* Overlay Cancel Button */}
-          <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10">
-            <Button
-              variant="destructive"
-              size="sm"
-              className="w-8 h-8 p-0 bg-red-600/90 hover:bg-red-700 text-white rounded-full shadow-lg"
-              onClick={handleCancel}
-            >
-              <X className="w-4 h-4" />
-            </Button>
-          </div>
-
           {isExpanded && (
             <CardContent className="pt-4 space-y-4">
               {/* Language Selection */}


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR adds a cancel button to the translation widget overlay to improve user experience. Users requested the ability to easily dismiss the widget when opened from the bookmarks section or when they no longer need the translation functionality.

## Code Changes

- **Added cancel button**: Imported `X` icon from lucide-react and added a cancel button to the widget header
- **Widget visibility state**: Introduced `isWidgetVisible` state to control widget display
- **Cancel functionality**: Implemented `handleCancel` function that:
  - Hides the widget
  - Resets all widget state (source text, translated text, minimized/expanded states)
- **Fallback UI**: Added a background view with a "Show LiveTranslate Widget" button when widget is hidden
- **Button styling**: Positioned cancel button in top-right corner with red hover states for clear visual indication

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/a59e801b3b1648eab93a95eb836c7b86/vortex-oasis)

👀 [Preview Link](https://a59e801b3b1648eab93a95eb836c7b86-vortex-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a59e801b3b1648eab93a95eb836c7b86</projectId>-->
<!--<branchName>vortex-oasis</branchName>-->